### PR TITLE
Change README.d pydot3 to pydot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Jupyter notebook can be found [here](https://nbviewer.jupyter.org/github/julio
 
 ## Requirements
 - Apache Spark (versions 2.0 and higher are supported).
-- Optionally, `pydot3` in the Spark driver if you plan to plot trees with th built-in functionality under PySpark. You can easily install it with `pip install pydot3`.
+- Optionally, `pydot` in the Spark driver if you plan to plot trees with th built-in functionality under PySpark. You can easily install it with `pip install pydot`.
 
 ## Installation
 


### PR DESCRIPTION
pydot3 was not working under Python 3.4.9, 3.6.5, 3.7 (on Mac and CentOS)
(ERROR Message is : startswith first arg must be str or a tuple of str, not bytes...)
(Pydot3 Issue is : https://github.com/log0/pydot3/issues/3)

So README.md change pydot3 to pydot.

Please, check this.

Signed-off-by: wlbhiro <wlbhiro@gmail.com>